### PR TITLE
Upgrade `ext.torch.Collate` to handle non-np.ndarray types

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The **abstract dataloader** (ADL) is a minimalist [specification](https://radarm
 
 ![Abstract Dataloader Overview](https://radarml.github.io/abstract-dataloader/diagrams/overview.svg)
 
-The ADL's specifications and bundled implementations lean heavily on generic type annotations in order to enable type checking using static type checkers such as [mypy](https://mypy-lang.org/) or [pyright](https://microsoft.github.io/pyright/) and runtime (dynamic) type checkers such as [beartype](https://github.com/beartype/beartype) and [typeguard](https://github.com/agronholm/typeguard), even when applying functor-like generic transforms such as sequence loading and transforms.
+The ADL's specifications and bundled implementations lean heavily on generic type annotations in order to enable type checking using static type checkers such as [mypy](https://mypy-lang.org/) or [pyright](https://microsoft.github.io/pyright/) and runtime (dynamic) type checkers such as [beartype](https://github.com/beartype/beartype) and [typeguard](https://github.com/agronholm/typeguard).
 
 > [!TIP]
 > Since the abstract dataloader uses python's [structural subtyping](https://typing.python.org/en/latest/spec/protocol.html) - `Protocol` - feature, the `abstract_dataloader` is not a required dependency for using the abstract dataloader! Implementations which follow the specifications are fully interoperable, including with type checkers, even if they do not have any mutual dependencies - including this library.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ The **abstract dataloader** (ADL) is a minimalist [specification][abstract_datal
 
 ![Abstract Dataloader Overview](./diagrams/overview.svg)
 
-The ADL's specifications and bundled implementations lean heavily on generic type annotations in order to enable type checking using static type checkers such as [mypy](https://mypy-lang.org/) or [pyright](https://microsoft.github.io/pyright/) and runtime (dynamic) type checkers such as [beartype](https://github.com/beartype/beartype) and [typeguard](https://github.com/agronholm/typeguard), even when applying functor-like generic transforms such as [sequence loading][abstract_dataloader.generic.Window] and [transforms][abstract_dataloader.generic.SequencePipeline].
+The ADL's specifications and bundled implementations lean heavily on generic type annotations in order to enable type checking using static type checkers such as [mypy](https://mypy-lang.org/) or [pyright](https://microsoft.github.io/pyright/) and runtime (dynamic) type checkers such as [beartype](https://github.com/beartype/beartype) and [typeguard](https://github.com/agronholm/typeguard).
 
 !!! tip "Structural Subtyping"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ plugins:
         - https://pytorch.org/docs/stable/objects.inv
         - https://docs.python.org/3/objects.inv
         - https://numpy.org/doc/stable/objects.inv
+        - https://optree.readthedocs.io/en/latest/objects.inv
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "abstract_dataloader"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
   { name="Tianshu Huang", email="tianshu2@andrew.cmu.edu" },
 ]

--- a/src/abstract_dataloader/ext/torch.py
+++ b/src/abstract_dataloader/ext/torch.py
@@ -58,7 +58,7 @@ class Collate(spec.Collate[TTransformed, TCollated]):
             else:  # "stack"
                 return torch.stack(values)
         elif self.convert_scalars and isinstance(values[0], (float, int, bool)):
-            return torch.Tensor(values)
+            return torch.tensor(values)
         else:
             return list(values)
 

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ conflicts = [[
 
 [[package]]
 name = "abstract-dataloader"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "jaxtyping" },


### PR DESCRIPTION
Implements #28, also adding a `convert_scalars: bool = True` arg which can be disabled to instead just collate values into a python list.